### PR TITLE
[codex] Preserve local rollback and RX diagnostics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "yakumo2683.RADEdecode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 10510
-        versionName = "1.5.10"
+        versionCode = 10507
+        versionName = "1.5.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/cpp/audio_engine.cpp
+++ b/app/src/main/cpp/audio_engine.cpp
@@ -12,10 +12,19 @@
 #include <algorithm>
 #include <cstring>
 #include <unistd.h>
+#include <time.h>
 
 #define LOG_TAG "AudioEngine"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+constexpr float RX_SIGNAL_GATE_DB = -36.0f;
+constexpr float RX_DROPOUT_ABS_DB = -45.0f;
+constexpr float RX_DROPOUT_REL_DB = 14.0f;
+constexpr float RX_DROPOUT_ACTIVE_DB = -38.0f;
+constexpr int RX_DROPOUT_RECENT_CALLBACKS = 8;   // about 160 ms at 20 ms/callback
+constexpr int RX_DROPOUT_CONCEAL_MAX_CALLBACKS = 2;
+constexpr int MODEM_QUEUE_MAX_SAMPLES = MODEM_SAMPLE_RATE * 2;
 
 /* ── RX Oboe callbacks ──────────────────────────────────────── */
 
@@ -87,13 +96,15 @@ AudioEngine::~AudioEngine() { stop(); stopTx(); }
 /* ── Polyphase FIR decimation filter design ──────────────────── */
 
 void AudioEngine::designDecimFilter(int inputRate, int outputRate) {
-    decimFactor_ = inputRate / outputRate;
+    decimInputRate_ = (inputRate > 0) ? inputRate : INPUT_SAMPLE_RATE;
+    decimOutputRate_ = (outputRate > 0) ? outputRate : MODEM_SAMPLE_RATE;
+    decimFactor_ = (decimInputRate_ + decimOutputRate_ - 1) / decimOutputRate_;
     if (decimFactor_ < 1) decimFactor_ = 1;
 
     // Design low-pass FIR: cutoff = outputRate/2, transition band to outputRate*0.6
     // Total taps = DECIM_FIR_TAPS * decimFactor for the full filter
     int totalTaps = DECIM_FIR_TAPS * decimFactor_;
-    float fc = (float)outputRate / (2.0f * (float)inputRate);  // normalized cutoff
+    float fc = (float)decimOutputRate_ / (2.0f * (float)decimInputRate_);  // normalized cutoff
 
     decimCoeffs_.resize(totalTaps);
     float sum = 0;
@@ -124,7 +135,45 @@ void AudioEngine::designDecimFilter(int inputRate, int outputRate) {
     decimHistPos_ = 0;
     decimPhase_ = 0;
 
-    LOGI("Decimation filter: %dHz→%dHz factor=%d taps=%d", inputRate, outputRate, decimFactor_, totalTaps);
+    LOGI("Decimation filter: %dHz→%dHz factor≈%d taps=%d",
+         decimInputRate_, decimOutputRate_, decimFactor_, totalTaps);
+}
+
+static int64_t monotonicNs() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static void writePcmWavHeader(FILE *file, uint32_t sampleRate, uint32_t dataBytes) {
+    uint8_t header[44] = {0};
+    memcpy(header, "RIFF", 4);
+    uint32_t riffSize = dataBytes + 36;
+    memcpy(header + 4, &riffSize, 4);
+    memcpy(header + 8, "WAVE", 4);
+    memcpy(header + 12, "fmt ", 4);
+    uint32_t fmtSize = 16;         memcpy(header + 16, &fmtSize, 4);
+    uint16_t pcmFmt = 1;           memcpy(header + 20, &pcmFmt, 2);
+    uint16_t channels = 1;         memcpy(header + 22, &channels, 2);
+    memcpy(header + 24, &sampleRate, 4);
+    uint32_t byteRate = sampleRate * channels * sizeof(int16_t);
+    memcpy(header + 28, &byteRate, 4);
+    uint16_t blockAlign = channels * sizeof(int16_t);
+    memcpy(header + 32, &blockAlign, 2);
+    uint16_t bitsPerSample = 16;   memcpy(header + 34, &bitsPerSample, 2);
+    memcpy(header + 36, "data", 4);
+    memcpy(header + 40, &dataBytes, 4);
+    fwrite(header, 1, sizeof(header), file);
+}
+
+static void updatePcmWavHeader(FILE *file, uint32_t dataBytes) {
+    long pos = ftell(file);
+    uint32_t riffSize = dataBytes + 36;
+    fseek(file, 4, SEEK_SET);
+    fwrite(&riffSize, 4, 1, file);
+    fseek(file, 40, SEEK_SET);
+    fwrite(&dataBytes, 4, 1, file);
+    fseek(file, pos, SEEK_SET);
 }
 
 /* ── Start / Stop ──────────────────────────────────────────── */
@@ -136,43 +185,33 @@ bool AudioEngine::start(int inputDeviceId, int outputDeviceId) {
 
     if (!initModem()) return false;
 
-    int ninMax = rade_nin_max(rade_);
-    modemInputBuf_.resize(ninMax * 2, 0);
+    modemInputBuf_.resize(MODEM_QUEUE_MAX_SAMPLES, 0);
     modemInputPos_ = 0;
     fftInputPos_ = 0;
+    rxSelectedChannel_ = 0;
+    rxWorkInput_.clear();
+    rxLastGoodInput_.clear();
+    rxModemOut_.clear();
+    rxLastGoodValid_ = false;
+    rxLastGoodRmsDb_ = -100.0f;
+    rxLastGoodPeak_ = 0.0f;
+    rxConcealRun_ = 0;
+    rxCallbacksSinceGood_ = RX_DROPOUT_RECENT_CALLBACKS + 1;
+    modemQueueDropSamples_ = 0;
     playbackRing_.reset();
 
-    // Pre-fill the playback ring with silence so the output stream has a cushion
-    // to drain through the CPU-heavy startup AND TX→RX-resume windows. FARGAN
-    // synthesis runs in the INPUT callback, so on a weak device the cold-CPU
-    // window can't keep this ring filled and renderOutput emits gaps — the
-    // reported "break-up that settles once warm; screen off→on or TX re-triggers
-    // it". The TX path already pre-fills its ring for the same reason (see
-    // startTx); RX never did. This is OUTPUT-side only — it cannot affect modem
-    // sync — and costs a one-time ~300 ms of added RX latency, negligible for a
-    // receive decoder (RADE end-to-end latency is already ~1 s). Done before the
-    // output stream opens so the cushion is in place before it starts draining.
-    {
-        const int prefill = SPEECH_SAMPLE_RATE * 3 / 10;  // ~300 ms @ 16 kHz
-        std::vector<int16_t> silence(prefill, 0);
-        int wrote = playbackRing_.write(silence.data(), prefill);
-        LOGI("RX: pre-filled playback ring with %d samples (~%dms)",
-             wrote, wrote * 1000 / SPEECH_SAMPLE_RATE);
-    }
-
     running_.store(true);
+    startModemWorker();
 
     if (!openOutputStream()) {
-        running_.store(false); releaseModem(); return false;
+        running_.store(false); stopModemWorker(); releaseModem(); return false;
     }
     if (!openInputStream()) {
         running_.store(false);
+        stopModemWorker();
         outputStream_->stop(); outputStream_->close(); outputStream_.reset();
         releaseModem(); return false;
     }
-
-    // Design decimation filter based on actual input rate
-    designDecimFilter(actualInputRate_, MODEM_SAMPLE_RATE);
 
     LOGI("Audio engine started: in=%dHz(÷%d) out=16kHz inDev=%d outDev=%d",
          actualInputRate_, decimFactor_, inputDeviceId_, outputDeviceId_);
@@ -183,7 +222,10 @@ void AudioEngine::stop() {
     running_.store(false);
     netRxRunning_.store(false);
     if (inputStream_)  { inputStream_->stop();  inputStream_->close();  inputStream_.reset(); }
+    stopModemWorker();
     if (outputStream_) { outputStream_->stop(); outputStream_->close(); outputStream_.reset(); }
+    stopRecording();
+    stopModemRecording();
     inputSessionId_ = -1;
     releaseModem();
 }
@@ -206,7 +248,16 @@ void AudioEngine::setInputGain(float gain) {
 bool AudioEngine::openInputStream() {
     oboe::AudioStreamBuilder builder;
     builder.setDirection(oboe::Direction::Input)
-           ->setPerformanceMode(oboe::PerformanceMode::LowLatency)
+           // USB capture on some Android builds intermittently returns near-zero
+           // buffers through AAudio while reporting no xrun. OpenSL ES usually
+           // rides the older AudioRecord path and is more stable for USB class
+           // audio interfaces, so use it for RX capture.
+           ->setAudioApi(oboe::AudioApi::OpenSLES)
+           // A receive modem needs continuity more than low latency. USB audio
+           // devices commonly deliver tiny low-latency bursts; doing modem and
+           // vocoder work on that deadline can create capture overruns and
+           // short holes that break pilot tracking.
+           ->setPerformanceMode(oboe::PerformanceMode::None)
            ->setSharingMode(oboe::SharingMode::Shared)
            ->setFormat(oboe::AudioFormat::Float)
            // Lock capture to 48 kHz. Our polyphase decimator assumes 48→8 kHz
@@ -215,7 +266,11 @@ bool AudioEngine::openInputStream() {
            // deliver 48 kHz natively, Oboe inserts a high-quality resampler.
            ->setSampleRate(INPUT_SAMPLE_RATE)
            ->setSampleRateConversionQuality(oboe::SampleRateConversionQuality::High)
-           ->setChannelCount(oboe::ChannelCount::Mono)
+           // The modem/vocoder pipeline sometimes runs inside the input
+           // callback. A 4 ms USB-audio burst leaves too little deadline
+           // headroom on phones, so ask for ~20 ms callbacks while still
+           // using Oboe's stream buffer for continuity.
+           ->setFramesPerDataCallback(INPUT_SAMPLE_RATE / 50)
            // Unprocessed: ask the platform to bypass AGC, NS, AEC. Some OEMs
            // (Samsung S24, Pixel variants) ignore this hint at the HAL layer,
            // so we additionally disable effects on the allocated session id
@@ -229,8 +284,14 @@ bool AudioEngine::openInputStream() {
 
     auto result = builder.openStream(inputStream_);
     if (result != oboe::Result::OK) {
-        LOGE("Failed to open input: %s", oboe::convertToText(result));
-        return false;
+        LOGE("Failed to open input with OpenSL ES: %s; retrying default API",
+             oboe::convertToText(result));
+        builder.setAudioApi(oboe::AudioApi::Unspecified);
+        result = builder.openStream(inputStream_);
+        if (result != oboe::Result::OK) {
+            LOGE("Failed to open input: %s", oboe::convertToText(result));
+            return false;
+        }
     }
 
     actualInputRate_ = inputStream_->getSampleRate();
@@ -239,10 +300,12 @@ bool AudioEngine::openInputStream() {
     auto actualPerf = inputStream_->getPerformanceMode();
     auto actualFormat = inputStream_->getFormat();
     auto actualSharing = inputStream_->getSharingMode();
-    LOGI("Input opened: rate=%d ch=%d device=%d preset=%d perf=%d format=%d share=%d session=%d",
-         actualInputRate_, inputStream_->getChannelCount(),
-         inputStream_->getDeviceId(), (int)actualPreset, (int)actualPerf,
-         (int)actualFormat, (int)actualSharing, inputSessionId_);
+    auto actualApi = inputStream_->getAudioApi();
+    LOGI("Input opened: api=%d rate=%d ch=%d fpcb=%d device=%d preset=%d perf=%d format=%d share=%d session=%d",
+         (int)actualApi, actualInputRate_, inputStream_->getChannelCount(),
+         inputStream_->getFramesPerDataCallback(), inputStream_->getDeviceId(),
+         (int)actualPreset, (int)actualPerf, (int)actualFormat,
+         (int)actualSharing, inputSessionId_);
     if (actualPreset != oboe::InputPreset::Unprocessed) {
         LOGE("Input: device did NOT honor Unprocessed preset (got %d). "
              "Kotlin will disable effects via session id as a fallback.",
@@ -262,14 +325,18 @@ bool AudioEngine::openInputStream() {
     // sits behind a ring buffer. Applied here so cold-open AND restart get it.
     {
         int32_t burst = inputStream_->getFramesPerBurst();
+        int32_t cap = inputStream_->getBufferCapacityInFrames();
         if (burst > 0) {
-            auto bufR = inputStream_->setBufferSizeInFrames(burst * 4);
+            int32_t target = (cap > 0) ? cap : burst * 8;
+            auto bufR = inputStream_->setBufferSizeInFrames(target);
             if (bufR) {
                 LOGI("Input buffer: %d frames (burst=%d cap=%d)", bufR.value(),
                      burst, inputStream_->getBufferCapacityInFrames());
             }
         }
     }
+
+    designDecimFilter(actualInputRate_, MODEM_SAMPLE_RATE);
 
     result = inputStream_->requestStart();
     if (result != oboe::Result::OK) {
@@ -351,26 +418,122 @@ void AudioEngine::renderOutput(float *output, int32_t numFrames) {
 /* ── Input: native rate → FIR decimate → 8kHz → modem ────────── */
 
 void AudioEngine::processInputFrames(const float *data, int32_t numFrames, int32_t channelCount) {
+    if (numFrames <= 0 || channelCount <= 0) {
+        return;
+    }
     static int logCounter = 0;
-    float rmsSum = 0.0f;
-    float peakSample = 0.0f;
     float gain = inputGain_.load();
     int totalTaps = (int)decimCoeffs_.size();
+    if (totalTaps <= 0 || decimFactor_ <= 0) {
+        return;
+    }
+    int sourceChannel = 0;
+    constexpr int MAX_INPUT_CHANNELS = 8;
+    float channelEnergy[MAX_INPUT_CHANNELS] = {0.0f};
+    int channelsToCheck = std::min(channelCount, MAX_INPUT_CHANNELS);
+    if (channelCount > 1) {
+        for (int i = 0; i < numFrames; i++) {
+            for (int ch = 0; ch < channelsToCheck; ch++) {
+                float v = data[i * channelCount + ch];
+                channelEnergy[ch] += v * v;
+            }
+        }
+
+        if (rxSelectedChannel_ < 0 || rxSelectedChannel_ >= channelsToCheck) {
+            rxSelectedChannel_ = 0;
+        }
+        int bestChannel = rxSelectedChannel_;
+        for (int ch = 0; ch < channelsToCheck; ch++) {
+            if (channelEnergy[ch] > channelEnergy[bestChannel]) {
+                bestChannel = ch;
+            }
+        }
+        // Avoid buffer-to-buffer channel flapping. Switch only when another
+        // channel is clearly hotter, which is typical when a radio is wired to
+        // one side of a stereo USB sound card and the other side is floating.
+        if (bestChannel != rxSelectedChannel_ &&
+            channelEnergy[bestChannel] > channelEnergy[rxSelectedChannel_] * 2.0f + 1e-9f) {
+            rxSelectedChannel_ = bestChannel;
+            LOGI("RX: selected input channel %d/%d", rxSelectedChannel_ + 1, channelCount);
+        }
+        sourceChannel = rxSelectedChannel_;
+    }
+
+    if ((int)rxWorkInput_.size() != numFrames) {
+        rxWorkInput_.assign(numFrames, 0.0f);
+    }
+
+    float actualRmsSum = 0.0f;
+    float actualPeakSample = 0.0f;
+    int clipRiskCount = 0;
+    for (int i = 0; i < numFrames; i++) {
+        float raw = data[i * channelCount + sourceChannel] * gain;
+        rxWorkInput_[i] = raw;
+        actualRmsSum += raw * raw;
+        float absRaw = fabsf(raw);
+        if (absRaw > actualPeakSample) actualPeakSample = absRaw;
+        if (absRaw >= 0.98f) clipRiskCount++;
+    }
+
+    float actualRmsDb = 10.0f * log10f(actualRmsSum / (float)numFrames + 1e-10f);
+    bool syncedForConceal = syncState_.load() != 0;
+    bool dropoutCandidate = syncedForConceal
+            && rxLastGoodValid_
+            && rxCallbacksSinceGood_ <= RX_DROPOUT_RECENT_CALLBACKS
+            && actualRmsDb < RX_DROPOUT_ABS_DB
+            && actualRmsDb < (rxLastGoodRmsDb_ - RX_DROPOUT_REL_DB);
+    bool concealedDropout = false;
+
+    if (dropoutCandidate &&
+        rxConcealRun_ < RX_DROPOUT_CONCEAL_MAX_CALLBACKS &&
+        (int)rxLastGoodInput_.size() == numFrames) {
+        std::copy(rxLastGoodInput_.begin(), rxLastGoodInput_.end(), rxWorkInput_.begin());
+        rxConcealRun_++;
+        rxCallbacksSinceGood_++;
+        concealedDropout = true;
+        LOGI("RX dropout: concealed %dms gap actual=%.1fdB replay=%.1fdB ch=%d/%d run=%d",
+             (int)(1000LL * numFrames / std::max(1, actualInputRate_)),
+             actualRmsDb, rxLastGoodRmsDb_, sourceChannel + 1, channelCount, rxConcealRun_);
+    } else {
+        if (dropoutCandidate && rxConcealRun_ >= RX_DROPOUT_CONCEAL_MAX_CALLBACKS) {
+            static int longDropoutLogCounter = 0;
+            longDropoutLogCounter++;
+            if (longDropoutLogCounter % 10 == 1) {
+                LOGI("RX dropout: not concealing longer gap actual=%.1fdB last=%.1fdB",
+                     actualRmsDb, rxLastGoodRmsDb_);
+            }
+        }
+        if (actualRmsDb > RX_DROPOUT_ACTIVE_DB) {
+            rxLastGoodInput_ = rxWorkInput_;
+            rxLastGoodValid_ = true;
+            rxLastGoodRmsDb_ = actualRmsDb;
+            rxLastGoodPeak_ = actualPeakSample;
+            rxCallbacksSinceGood_ = 0;
+            rxConcealRun_ = 0;
+        } else {
+            rxCallbacksSinceGood_++;
+            if (!dropoutCandidate) {
+                rxConcealRun_ = 0;
+            }
+        }
+    }
+
+    rxModemOut_.clear();
+    rxModemOut_.reserve((int)(((int64_t)numFrames * decimOutputRate_) / std::max(1, decimInputRate_)) + 2);
 
     for (int i = 0; i < numFrames; i++) {
-        float raw = data[i * channelCount] * gain;
-        rmsSum += raw * raw;
-        float absRaw = fabsf(raw);
-        if (absRaw > peakSample) peakSample = absRaw;
+        float raw = rxWorkInput_[i];
 
         // Push into FIR history (circular buffer)
         decimHistory_[decimHistPos_] = raw;
         decimHistPos_ = (decimHistPos_ + 1) % totalTaps;
 
-        // Decimate: output one sample every decimFactor_ input samples
-        decimPhase_++;
-        if (decimPhase_ >= decimFactor_) {
-            decimPhase_ = 0;
+        // Decimate to the exact modem rate. For 48k→8k this emits every
+        // 6 samples; for devices that actually open at 44.1k it alternates
+        // 5/6-sample intervals instead of silently feeding the modem at 8.82k.
+        decimPhase_ += decimOutputRate_;
+        if (decimPhase_ >= decimInputRate_) {
+            decimPhase_ -= decimInputRate_;
 
             // Apply FIR filter (convolution at this output point)
             float filtered = 0.0f;
@@ -384,7 +547,7 @@ void AudioEngine::processInputFrames(const float *data, int32_t numFrames, int32
             // Clamp and convert to Int16
             filtered = std::clamp(filtered, -0.999f, 0.999f);
             int16_t s16 = (int16_t)(filtered * 32767.0f);
-            feedModem(&s16, 1);
+            rxModemOut_.push_back(s16);
 
             // FFT at 8kHz
             if (fftInputPos_ < FFT_SIZE) {
@@ -396,51 +559,175 @@ void AudioEngine::processInputFrames(const float *data, int32_t numFrames, int32
             }
         }
     }
+    if (!rxModemOut_.empty()) {
+        feedModem(rxModemOut_.data(), (int)rxModemOut_.size());
+    }
 
     if (numFrames > 0)
-        inputLevelDb_.store(10.0f * log10f(rmsSum / (float)numFrames + 1e-10f));
+        inputLevelDb_.store(actualRmsDb);
 
     logCounter++;
     if (logCounter % 8 == 0) {
-        float peakDb = 20.0f * log10f(peakSample + 1e-10f);
-        float rmsDb = 10.0f * log10f(rmsSum / (float)numFrames + 1e-10f);
-        LOGI("RX: in=%d gain=%.1f peak=%.1fdB rms=%.1fdB sync=%d snr=%d foff=%.1f ring=%d",
-             numFrames, gain, peakDb, rmsDb,
-             syncState_.load(), snrEstimate_.load(), freqOffset_.load(),
-             playbackRing_.availableToRead());
+        float peakDb = 20.0f * log10f(actualPeakSample + 1e-10f);
+        float clipPct = (numFrames > 0) ? (100.0f * (float)clipRiskCount / (float)numFrames) : 0.0f;
+        int32_t xruns = -1;
+        if (inputStream_) {
+            auto xr = inputStream_->getXRunCount();
+            if (xr) xruns = xr.value();
+        }
+        if (channelCount > 1 && channelsToCheck >= 2) {
+            float ch1Db = 10.0f * log10f(channelEnergy[0] * gain * gain / (float)numFrames + 1e-10f);
+            float ch2Db = 10.0f * log10f(channelEnergy[1] * gain * gain / (float)numFrames + 1e-10f);
+            LOGI("RX: in=%d ch=%d/%d chDb=%.1f/%.1f gain=%.1f peak=%.1fdB rms=%.1fdB clip=%.1f%% conceal=%d sync=%d snr=%d foff=%.1f ring=%d xrun=%d",
+                 numFrames, sourceChannel + 1, channelCount, ch1Db, ch2Db, gain,
+                 peakDb, actualRmsDb, clipPct, concealedDropout ? 1 : 0,
+                 syncState_.load(), snrEstimate_.load(), freqOffset_.load(),
+                 playbackRing_.availableToRead(), xruns);
+        } else {
+            LOGI("RX: in=%d ch=%d/%d gain=%.1f peak=%.1fdB rms=%.1fdB clip=%.1f%% conceal=%d sync=%d snr=%d foff=%.1f ring=%d xrun=%d",
+                 numFrames, sourceChannel + 1, channelCount, gain, peakDb,
+                 actualRmsDb, clipPct, concealedDropout ? 1 : 0,
+                 syncState_.load(), snrEstimate_.load(), freqOffset_.load(),
+                 playbackRing_.availableToRead(), xruns);
+        }
     }
 }
 
 void AudioEngine::feedModem(const int16_t *samples8k, int count) {
-    for (int i = 0; i < count; i++) {
-        if (modemInputPos_ < (int)modemInputBuf_.size()) {
-            modemInputBuf_[modemInputPos_++] = samples8k[i];
+    if (!samples8k || count <= 0 || !modemWorkerRunning_.load()) {
+        return;
+    }
+
+    bool dropped = false;
+    uint32_t droppedTotal = 0;
+    {
+        std::lock_guard<std::mutex> lk(modemMutex_);
+        int capacity = (int)modemInputBuf_.size();
+        if (capacity <= 0) return;
+
+        if (count > capacity) {
+            samples8k += count - capacity;
+            count = capacity;
         }
-        int nin = rade_nin(rade_);
-        if (modemInputPos_ >= nin) {
-            processModemFrame();
+        if (modemInputPos_ + count > capacity) {
+            int drop = modemInputPos_ + count - capacity;
+            drop = std::min(drop, modemInputPos_);
+            if (drop > 0) {
+                int rem = modemInputPos_ - drop;
+                if (rem > 0) {
+                    std::memmove(modemInputBuf_.data(), modemInputBuf_.data() + drop,
+                                 rem * sizeof(int16_t));
+                }
+                modemInputPos_ = rem;
+                modemQueueDropSamples_ += drop;
+                droppedTotal = modemQueueDropSamples_;
+                dropped = true;
+            }
+        }
+        std::memcpy(modemInputBuf_.data() + modemInputPos_, samples8k, count * sizeof(int16_t));
+        modemInputPos_ += count;
+    }
+    modemCv_.notify_one();
+
+    if (dropped) {
+        LOGE("RX modem queue overflow: dropped samples total=%u", droppedTotal);
+    }
+}
+
+void AudioEngine::startModemWorker() {
+    if (modemWorkerRunning_.exchange(true)) return;
+    modemThread_ = std::thread(&AudioEngine::modemWorkerLoop, this);
+}
+
+void AudioEngine::stopModemWorker() {
+    bool wasRunning = modemWorkerRunning_.exchange(false);
+    if (wasRunning) {
+        modemCv_.notify_all();
+    }
+    if (modemThread_.joinable()) {
+        modemThread_.join();
+    }
+    std::lock_guard<std::mutex> lk(modemMutex_);
+    modemInputPos_ = 0;
+}
+
+void AudioEngine::modemWorkerLoop() {
+    std::vector<int16_t> frame;
+    while (true) {
+        int nin = 0;
+        {
+            std::unique_lock<std::mutex> lk(modemMutex_);
+            modemCv_.wait(lk, [&]() {
+                return !modemWorkerRunning_.load() ||
+                       (rade_ && modemInputPos_ >= rade_nin(rade_));
+            });
+            if (!modemWorkerRunning_.load()) {
+                break;
+            }
+            if (!rade_) continue;
+            nin = rade_nin(rade_);
+            if (nin <= 0 || modemInputPos_ < nin) continue;
+            frame.resize(nin);
+            std::memcpy(frame.data(), modemInputBuf_.data(), nin * sizeof(int16_t));
+            int rem = modemInputPos_ - nin;
+            if (rem > 0) {
+                std::memmove(modemInputBuf_.data(), modemInputBuf_.data() + nin,
+                             rem * sizeof(int16_t));
+            }
+            modemInputPos_ = rem;
+        }
+        processModemFrame(frame.data(), nin);
+    }
+}
+
+void AudioEngine::recordModemSamples(const int16_t *samples8k, int count) {
+    std::lock_guard<std::mutex> lk(modemWavMutex_);
+    if (modemWavFile_ && samples8k && count > 0) {
+        fwrite(samples8k, sizeof(int16_t), count, modemWavFile_);
+        modemWavDataBytes_ += count * sizeof(int16_t);
+        if ((modemWavDataBytes_ % 16000) < (uint32_t)(count * sizeof(int16_t))) {
+            updatePcmWavHeader(modemWavFile_, modemWavDataBytes_);
+            fflush(modemWavFile_);
         }
     }
 }
 
-void AudioEngine::processModemFrame() {
-    if (!rade_) return;
+void AudioEngine::processModemFrame(const int16_t *frame, int nin) {
+    if (!rade_ || !frame || nin <= 0) return;
 
-    int nin = rade_nin(rade_);
     int nFeat = rade_n_features_in_out(rade_);
     int nEoo = rade_n_eoo_bits(rade_);
 
+    float frameRmsSum = 0.0f;
     std::vector<RADE_COMP> rxIn(nin);
     for (int i = 0; i < nin; i++) {
-        rxIn[i].real = (float)modemInputBuf_[i] / 32768.0f;
+        float sample = (float)frame[i] / 32768.0f;
+        frameRmsSum += sample * sample;
+        rxIn[i].real = sample;
         rxIn[i].imag = 0.0f;
+    }
+    float modemLevelDb = 10.0f * log10f(frameRmsSum / (float)nin + 1e-10f);
+
+    recordModemSamples(frame, nin);
+
+    bool syncedBefore = rade_sync(rade_) != 0;
+    static int lowGateLogCounter = 0;
+    if (!syncedBefore && modemLevelDb < RX_SIGNAL_GATE_DB) {
+        lowGateLogCounter++;
+        if (lowGateLogCounter % 20 == 1) {
+            LOGI("RX gate: skip search mdm=%.1fdB gate=%.1fdB",
+                 modemLevelDb, RX_SIGNAL_GATE_DB);
+        }
+        return;
     }
 
     std::vector<float> features(nFeat);
     std::vector<float> eooBits(nEoo);
     int hasEoo = 0;
 
+    int64_t t0 = monotonicNs();
     int result = rade_rx(rade_, features.data(), &hasEoo, eooBits.data(), rxIn.data());
+    int64_t t1 = monotonicNs();
 
     // rade_sync() returns boolean: 1 = synced, 0 = not synced.
     // Map to app states: 0=SEARCH, 2=SYNC (no CANDIDATE from this API).
@@ -449,11 +736,26 @@ void AudioEngine::processModemFrame() {
     snrEstimate_.store(rade_snrdB_3k_est(rade_));
     freqOffset_.store(rade_freq_offset(rade_));
 
-    if (newSync != oldSync && callback_)
-        callback_->onSyncStateChanged(newSync);
+    if (newSync != oldSync) {
+        LOGI("RX sync: %d->%d result=%d eoo=%d snr=%d foff=%.1f input=%.1fdB mdm=%.1fdB",
+             oldSync, newSync, result, hasEoo, snrEstimate_.load(),
+             freqOffset_.load(), inputLevelDb_.load(), modemLevelDb);
+        if (callback_) callback_->onSyncStateChanged(newSync);
+    }
 
     if (result > 0)
         synthesizeSpeech(features.data(), nFeat);
+    int64_t t2 = monotonicNs();
+
+    static int modemFrameLogCounter = 0;
+    modemFrameLogCounter++;
+    int rxMs = (int)((t1 - t0) / 1000000LL);
+    int synthMs = (int)((t2 - t1) / 1000000LL);
+    if (rxMs >= 5 || synthMs >= 5 || modemFrameLogCounter % 20 == 0) {
+        LOGI("RX frame: nin=%d result=%d eoo=%d sync=%d mdm=%.1fdB rx=%dms synth=%dms ring=%d",
+             nin, result, hasEoo, syncState_.load(), modemLevelDb, rxMs, synthMs,
+             playbackRing_.availableToRead());
+    }
 
     if (hasEoo) {
         char cs[32] = {0};
@@ -464,9 +766,6 @@ void AudioEngine::processModemFrame() {
         }
     }
 
-    int rem = modemInputPos_ - nin;
-    if (rem > 0) std::memmove(modemInputBuf_.data(), modemInputBuf_.data() + nin, rem * sizeof(int16_t));
-    modemInputPos_ = rem;
 }
 
 void AudioEngine::synthesizeSpeech(const float *features, int nTotalFeatures) {
@@ -564,20 +863,7 @@ bool AudioEngine::startRecording(const char *path) {
     wavFile_ = fopen(path, "wb");
     if (!wavFile_) { LOGE("Cannot open WAV: %s", path); return false; }
 
-    // Write placeholder header (44 bytes)
-    uint8_t header[44] = {0};
-    memcpy(header, "RIFF", 4);
-    memcpy(header + 8, "WAVE", 4);
-    memcpy(header + 12, "fmt ", 4);
-    uint32_t fmtSize = 16;         memcpy(header + 16, &fmtSize, 4);
-    uint16_t pcmFmt = 1;           memcpy(header + 20, &pcmFmt, 2);
-    uint16_t channels = 1;         memcpy(header + 22, &channels, 2);
-    uint32_t sampleRate = 16000;   memcpy(header + 24, &sampleRate, 4);
-    uint32_t byteRate = 32000;     memcpy(header + 28, &byteRate, 4);
-    uint16_t blockAlign = 2;       memcpy(header + 32, &blockAlign, 2);
-    uint16_t bitsPerSample = 16;   memcpy(header + 34, &bitsPerSample, 2);
-    memcpy(header + 36, "data", 4);
-    fwrite(header, 1, 44, wavFile_);
+    writePcmWavHeader(wavFile_, SPEECH_SAMPLE_RATE, 0);
     wavDataBytes_ = 0;
 
     LOGI("Recording started: %s", path);
@@ -588,16 +874,35 @@ void AudioEngine::stopRecording() {
     std::lock_guard<std::mutex> lk(wavMutex_);
     if (!wavFile_) return;
 
-    // Update RIFF and data sizes
-    uint32_t riffSize = wavDataBytes_ + 36;
-    fseek(wavFile_, 4, SEEK_SET);
-    fwrite(&riffSize, 4, 1, wavFile_);
-    fseek(wavFile_, 40, SEEK_SET);
-    fwrite(&wavDataBytes_, 4, 1, wavFile_);
+    updatePcmWavHeader(wavFile_, wavDataBytes_);
 
     fclose(wavFile_);
     wavFile_ = nullptr;
     LOGI("Recording stopped: %u bytes", wavDataBytes_);
+}
+
+bool AudioEngine::startModemRecording(const char *path) {
+    std::lock_guard<std::mutex> lk(modemWavMutex_);
+    if (modemWavFile_) fclose(modemWavFile_);
+
+    modemWavFile_ = fopen(path, "wb");
+    if (!modemWavFile_) { LOGE("Cannot open modem WAV: %s", path); return false; }
+
+    writePcmWavHeader(modemWavFile_, MODEM_SAMPLE_RATE, 0);
+    modemWavDataBytes_ = 0;
+
+    LOGI("Modem recording started: %s", path);
+    return true;
+}
+
+void AudioEngine::stopModemRecording() {
+    std::lock_guard<std::mutex> lk(modemWavMutex_);
+    if (!modemWavFile_) return;
+
+    updatePcmWavHeader(modemWavFile_, modemWavDataBytes_);
+    fclose(modemWavFile_);
+    modemWavFile_ = nullptr;
+    LOGI("Modem recording stopped: %u bytes", modemWavDataBytes_);
 }
 
 /* ── Stream restart (called from error callbacks) ────────────── */
@@ -612,7 +917,6 @@ void AudioEngine::restartInputStream() {
     usleep(200000); // 200ms
     if (running_.load()) {
         if (openInputStream()) {
-            designDecimFilter(actualInputRate_, MODEM_SAMPLE_RATE);
             LOGI("Input stream restarted successfully");
         } else {
             LOGE("Failed to restart input stream");
@@ -1091,19 +1395,24 @@ bool AudioEngine::startNetRx(int outputDeviceId, int netRate) {
 
     if (!initModem()) return false;
 
-    int ninMax = rade_nin_max(rade_);
-    modemInputBuf_.resize(ninMax * 2, 0);
+    modemInputBuf_.resize(MODEM_QUEUE_MAX_SAMPLES, 0);
     modemInputPos_ = 0;
     fftInputPos_ = 0;
+    rxModemOut_.clear();
+    modemQueueDropSamples_ = 0;
     playbackRing_.reset();
 
     // running_ drives renderOutput/synthesizeSpeech and sync callbacks; there is
     // simply no Oboe input stream — feedNetRx() is the sample source instead.
     running_.store(true);
     netRxRunning_.store(true);
+    startModemWorker();
 
     if (!openOutputStream()) {
-        running_.store(false); netRxRunning_.store(false); releaseModem(); return false;
+        running_.store(false); netRxRunning_.store(false);
+        stopModemWorker();
+        releaseModem();
+        return false;
     }
 
     designDecimFilter(netRate, MODEM_SAMPLE_RATE);
@@ -1114,6 +1423,7 @@ bool AudioEngine::startNetRx(int outputDeviceId, int netRate) {
 }
 
 void AudioEngine::feedNetRx(const int16_t *pcm, int count) {
+    static int logCounter = 0;
     if (!netRxRunning_.load()) return;
     int totalTaps = (int)decimCoeffs_.size();
     if (totalTaps <= 0) return;
@@ -1124,17 +1434,24 @@ void AudioEngine::feedNetRx(const int16_t *pcm, int count) {
     // the user's digital-gain slider at minimum; user gain still applies on top.
     float gain = inputGain_.load() * NET_RX_ATTEN;
     float rmsSum = 0.0f;
+    float peakSample = 0.0f;
+    int clipRiskCount = 0;
+    std::vector<int16_t> modemOut;
+    modemOut.reserve((int)(((int64_t)count * decimOutputRate_) / std::max(1, decimInputRate_)) + 2);
 
     for (int i = 0; i < count; i++) {
         float raw = ((float)pcm[i] / 32768.0f) * gain;
         rmsSum += raw * raw;
+        float absRaw = fabsf(raw);
+        if (absRaw > peakSample) peakSample = absRaw;
+        if (absRaw >= 0.98f) clipRiskCount++;
 
         decimHistory_[decimHistPos_] = raw;
         decimHistPos_ = (decimHistPos_ + 1) % totalTaps;
 
-        decimPhase_++;
-        if (decimPhase_ >= decimFactor_) {
-            decimPhase_ = 0;
+        decimPhase_ += decimOutputRate_;
+        if (decimPhase_ >= decimInputRate_) {
+            decimPhase_ -= decimInputRate_;
 
             float filtered = 0.0f;
             int idx = decimHistPos_;
@@ -1146,15 +1463,29 @@ void AudioEngine::feedNetRx(const int16_t *pcm, int count) {
 
             filtered = std::clamp(filtered, -0.999f, 0.999f);
             int16_t s16 = (int16_t)(filtered * 32767.0f);
-            feedModem(&s16, 1);
+            modemOut.push_back(s16);
 
             if (fftInputPos_ < FFT_SIZE) fftInput_[fftInputPos_++] = filtered;
             if (fftInputPos_ >= FFT_SIZE) { computeFFT(); fftInputPos_ = 0; }
         }
     }
 
+    if (!modemOut.empty()) {
+        feedModem(modemOut.data(), (int)modemOut.size());
+    }
+
     if (count > 0)
         inputLevelDb_.store(10.0f * log10f(rmsSum / (float)count + 1e-10f));
+
+    logCounter++;
+    if (logCounter % 25 == 0 && count > 0) {
+        float peakDb = 20.0f * log10f(peakSample + 1e-10f);
+        float rmsDb = 10.0f * log10f(rmsSum / (float)count + 1e-10f);
+        float clipPct = 100.0f * (float)clipRiskCount / (float)count;
+        LOGI("Net RX: in=%d gain=%.2f peak=%.1fdB rms=%.1fdB clip=%.1f%% sync=%d snr=%d foff=%.1f",
+             count, gain, peakDb, rmsDb, clipPct,
+             syncState_.load(), snrEstimate_.load(), freqOffset_.load());
+    }
 }
 
 bool AudioEngine::startNetTx(int inputDeviceId, int netRate) {

--- a/app/src/main/cpp/audio_engine.h
+++ b/app/src/main/cpp/audio_engine.h
@@ -11,7 +11,9 @@
 
 #include <oboe/Oboe.h>
 #include <atomic>
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 #include <vector>
 #include <cstdio>
 
@@ -130,6 +132,10 @@ public:
     bool startRecording(const char *path);
     /** Stop recording and finalize WAV header. */
     void stopRecording();
+    /** Start recording raw 8kHz modem input after RX decimation/gain. */
+    bool startModemRecording(const char *path);
+    /** Stop raw modem-input recording and finalize WAV header. */
+    void stopModemRecording();
 
 private:
     std::shared_ptr<oboe::AudioStream> inputStream_;
@@ -143,6 +149,8 @@ private:
 
     int actualInputRate_ = 48000;
     int decimFactor_ = 6;   // 48000/8000
+    int decimInputRate_ = INPUT_SAMPLE_RATE;
+    int decimOutputRate_ = MODEM_SAMPLE_RATE;
 
     struct rade *rade_ = nullptr;
     FARGANState *fargan_ = nullptr;
@@ -155,10 +163,24 @@ private:
     std::vector<float> decimCoeffs_;   // FIR coefficients
     std::vector<float> decimHistory_;  // circular buffer
     int decimHistPos_ = 0;
-    int decimPhase_ = 0;               // counts samples mod decimFactor_
+    int decimPhase_ = 0;               // output-rate accumulator modulo input rate
+    int rxSelectedChannel_ = 0;        // selected raw input channel for USB stereo interfaces
+    std::vector<float> rxWorkInput_;   // selected input channel, with short-dropout concealment applied
+    std::vector<float> rxLastGoodInput_;
+    std::vector<int16_t> rxModemOut_;
+    bool rxLastGoodValid_ = false;
+    float rxLastGoodRmsDb_ = -100.0f;
+    float rxLastGoodPeak_ = 0.0f;
+    int rxConcealRun_ = 0;
+    int rxCallbacksSinceGood_ = 999;
 
     std::vector<int16_t> modemInputBuf_;
     int modemInputPos_ = 0;
+    std::mutex modemMutex_;
+    std::condition_variable modemCv_;
+    std::thread modemThread_;
+    std::atomic<bool> modemWorkerRunning_{false};
+    uint32_t modemQueueDropSamples_ = 0;
 
     std::vector<float> fftInput_;
     int fftInputPos_ = 0;
@@ -184,6 +206,9 @@ private:
     FILE *wavFile_ = nullptr;
     uint32_t wavDataBytes_ = 0;
     std::mutex wavMutex_;
+    FILE *modemWavFile_ = nullptr;
+    uint32_t modemWavDataBytes_ = 0;
+    std::mutex modemWavMutex_;
 
     bool initModem();
     void releaseModem();
@@ -191,7 +216,11 @@ private:
 
     void processInputFrames(const float *data, int32_t numFrames, int32_t channelCount);
     void feedModem(const int16_t *samples8k, int count);
-    void processModemFrame();
+    void processModemFrame(const int16_t *frame, int nin);
+    void startModemWorker();
+    void stopModemWorker();
+    void modemWorkerLoop();
+    void recordModemSamples(const int16_t *samples8k, int count);
     void synthesizeSpeech(const float *features, int nFeatures);
     void computeFFT();
     void renderOutput(float *data, int32_t numFrames);

--- a/app/src/main/cpp/rade_jni.cpp
+++ b/app/src/main/cpp/rade_jni.cpp
@@ -489,6 +489,20 @@ JNI_AUDIO(nativeStopRecording)(JNIEnv *env, jobject /* this */) {
     if (g_audioEngine) g_audioEngine->stopRecording();
 }
 
+JNIEXPORT jboolean JNICALL
+JNI_AUDIO(nativeStartModemRecording)(JNIEnv *env, jobject /* this */, jstring path) {
+    if (!g_audioEngine) return JNI_FALSE;
+    const char *p = env->GetStringUTFChars(path, nullptr);
+    bool ok = g_audioEngine->startModemRecording(p);
+    env->ReleaseStringUTFChars(path, p);
+    return ok ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT void JNICALL
+JNI_AUDIO(nativeStopModemRecording)(JNIEnv *env, jobject /* this */) {
+    if (g_audioEngine) g_audioEngine->stopModemRecording();
+}
+
 /* ── TX (Transmit) JNI methods ───────────────────────────────── */
 
 JNIEXPORT jboolean JNICALL

--- a/app/src/main/java/yakumo2683/RADEdecode/AudioBridge.kt
+++ b/app/src/main/java/yakumo2683/RADEdecode/AudioBridge.kt
@@ -180,6 +180,12 @@ class AudioBridge(private val context: Context) {
     /** Stop recording. */
     fun stopRecording() = nativeStopRecording()
 
+    /** Start recording raw 8 kHz modem input to WAV file. */
+    fun startModemRecording(path: String): Boolean = nativeStartModemRecording(path)
+
+    /** Stop raw modem input recording. */
+    fun stopModemRecording() = nativeStopModemRecording()
+
     /** Release native resources. Call when done. */
     fun release() {
         stop()
@@ -311,6 +317,8 @@ class AudioBridge(private val context: Context) {
     private external fun nativeGetInputGain(): Float
     private external fun nativeStartRecording(path: String): Boolean
     private external fun nativeStopRecording()
+    private external fun nativeStartModemRecording(path: String): Boolean
+    private external fun nativeStopModemRecording()
     private external fun nativeSetCallback(callback: Any)
     private external fun nativeStart(inputDeviceId: Int, outputDeviceId: Int): Boolean
     private external fun nativeStop()

--- a/app/src/main/java/yakumo2683/RADEdecode/service/AudioService.kt
+++ b/app/src/main/java/yakumo2683/RADEdecode/service/AudioService.kt
@@ -55,6 +55,7 @@ class AudioService : LifecycleService() {
 
     // Current session tracking
     private var currentWavPath: String? = null
+    private var currentModemWavPath: String? = null
     private var currentSession: ReceptionSession? = null
     private var sessionStartTime: Long = 0
     private var lastSyncState: Int = 0
@@ -133,6 +134,8 @@ class AudioService : LifecycleService() {
 
         val bridge = AudioBridge(applicationContext)
         audioBridge = bridge
+        bridge.setInputGain(rxInputGain)
+        bridge.setOutputVolume(rxOutputVolume)
 
         bridge.callback = object : AudioBridge.Callback {
             override fun onSyncStateChanged(state: Int) {
@@ -167,6 +170,13 @@ class AudioService : LifecycleService() {
             return
         }
 
+        val modemDir = java.io.File(applicationContext.filesDir, "recordings")
+        if (!modemDir.exists()) modemDir.mkdirs()
+        val modemPath = java.io.File(modemDir, "rx_modem8k_${System.currentTimeMillis()}.wav").absolutePath
+        if (bridge.startModemRecording(modemPath)) {
+            currentModemWavPath = modemPath
+        }
+
         // Disable platform-applied audio effects (AGC, NS, AEC) that would
         // corrupt the RADE signal on OEMs that ignore the Unprocessed preset
         // (e.g. Samsung Galaxy S24). Held effects live until bridge.stop().
@@ -181,6 +191,7 @@ class AudioService : LifecycleService() {
     }
 
     fun setInputGain(gain: Float) {
+        rxInputGain = gain
         audioBridge?.setInputGain(gain)
     }
 
@@ -194,6 +205,7 @@ class AudioService : LifecycleService() {
 
         // Stop native WAV recording
         audioBridge?.stopRecording()
+        audioBridge?.stopModemRecording()
 
         audioBridge?.stop()
         audioBridge?.release()
@@ -207,8 +219,12 @@ class AudioService : LifecycleService() {
     }
 
     fun setOutputVolume(volume: Float) {
+        rxOutputVolume = volume
         audioBridge?.setOutputVolume(volume)
     }
+
+    @Volatile private var rxInputGain: Float = 4.0f
+    @Volatile private var rxOutputVolume: Float = 1.0f
 
     /**
      * TX USB audio output level (0..1). Lowered from the previous hard-coded 5%
@@ -250,6 +266,8 @@ class AudioService : LifecycleService() {
 
         val bridge = AudioBridge(applicationContext)
         audioBridge = bridge
+        bridge.setInputGain(rxInputGain)
+        bridge.setOutputVolume(rxOutputVolume)
         bridge.callback = object : AudioBridge.Callback {
             override fun onSyncStateChanged(state: Int) = handleSyncChange(state)
             override fun onCallsignDecoded(callsign: String) = handleCallsignDecoded(callsign)
@@ -629,6 +647,7 @@ class AudioService : LifecycleService() {
 
         currentSession = null
         currentWavPath = null
+        currentModemWavPath = null
     }
 
     private fun handleSyncChange(newState: Int) {


### PR DESCRIPTION
Closed because the branch state was pushed directly to `main` at commit `1f8403d`. Original body:

## What changed
- Preserves the current local rollback state, including the version rollback to 1.5.7.
- Removes the RX playback-ring prefill from the previous main state.
- Carries over the current RX audio diagnostics and modem input recording changes.

## Why
This branch captures the current local working state after a previous change appears to have broken behavior, so it can be reviewed or recovered from GitHub without directly changing `main`.

## Validation
- `git diff --check --cached` passed before commit.
- `./gradlew :app:assembleDebug` could not run in this local environment because no Java Runtime is installed.