### PR TITLE
Fix Icom Wi-Fi login wedge on IC-7300MK2 + make login retries effective (v1.6.11)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "yakumo2683.RADEdecode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 10610
-        versionName = "1.6.10-reporter-grid-manualfreq"
+        versionCode = 10611
+        versionName = "1.6.11-icom-login-unwedge"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/yakumo2683/RADEdecode/network/IcomNetworkManager.kt
+++ b/app/src/main/java/yakumo2683/RADEdecode/network/IcomNetworkManager.kt
@@ -181,35 +181,57 @@ class IcomNetworkManager : NetworkAudioRig {
             val ctrl = IcomStream("control", host, controlPort, scope)
             control = ctrl
             if (!ctrl.open()) {
-                fail("Control handshake failed — check the IP and that the radio is reachable")
+                fail("Control handshake failed — no reply from $host:$controlPort. " +
+                     "Check the IP and that the radio is reachable. Over a VPN the radio " +
+                     "also needs a default gateway (or the VPN must NAT clients into the " +
+                     "radio's subnet), or it cannot send replies back.")
                 disconnect(); return ""
             }
 
-            // Pre-login cleanup: remove the PREVIOUS session's token first. If
-            // the last run ended uncleanly (app killed while connected), the
-            // radio still holds that token and would silently ignore this
-            // login. Removal is idempotent — deleting an already-expired token
-            // is a no-op — so it is sent on every connect. The token is looked
-            // up by its value; the packet rides the fresh control stream.
+            // Pre-login cleanup: remove the PREVIOUS session's token, but only
+            // when one was actually left behind by an UNCLEAN exit (app killed
+            // while connected). The persisted copy is cleared the moment the
+            // removal is sent — and on every clean disconnect — because radios
+            // differ in how they treat a removal for an unknown token: the
+            // IC-705 (fw 1.41) silently ignores it, but a radio that ANSWERS
+            // 0x40 packets (IC-7300MK2) consumes its tracked sequence numbers
+            // before the login reply, and an unconditional removal on every
+            // connect then wedged every login after the first.
             loadStaleToken?.invoke()?.let { hexTok ->
                 parseTokenHex(hexTok)?.let { oldTok ->
-                    Log.i(TAG, "removing stale token from previous session")
-                    repeat(3) { ctrl.sendRaw(buildTokenRemove(ctrl, oldTok)) }
+                    Log.i(TAG, "removing stale token left by an unclean exit")
+                    val remove = buildTokenRemove(ctrl, oldTok)
+                    repeat(3) { ctrl.sendRaw(remove) }   // identical repeats = native retransmit idiom
                     delay(150)
                 }
+                saveStaleToken?.invoke(null)             // one-shot: never resend it
             }
 
+            // Login reply = the 96-byte tracked data packet (type 0x60). Bytes
+            // 6-7 carry the RADIO's running tracking seq — never match on them:
+            // they are 0x0001 only when the reply happens to be the radio's
+            // very first tracked packet. A reply the radio sends to the
+            // pre-login token removal, or a login retry after a lost first
+            // reply, shifts that seq, and a matcher pinned to 0x0001 then
+            // drops every real login reply ("No login reply" although the
+            // radio answered).
+            val loginReply = byteArrayOf(0x60, 0, 0, 0, 0, 0)
+            // Anything already queued arrived BEFORE the login left (e.g. a
+            // radio's ack to the token removal, whatever its shape) — drop it
+            // so it cannot be mistaken for the login reply. The real reply
+            // cannot arrive before the login is sent.
+            ctrl.drainPending()
             ctrl.sendTracked(buildLogin(ctrl))                       // authInnerSeq 0 → login
             // 5 s window per attempt, up to 3 attempts: a lost login packet on a
             // cold path, or a radio still flushing a just-expired previous
             // session, both recover on a resend instead of failing the connect.
-            var r60 = ctrl.expect(96, byteArrayOf(0x60, 0, 0, 0, 0, 0, 0x01, 0), timeoutMs = 5000)
+            var r60 = ctrl.expect(96, loginReply, timeoutMs = 5000)
             var loginAttempt = 1
             while (r60 == null && loginAttempt < 3) {
                 loginAttempt++
                 Log.i(TAG, "no login reply; resending login (attempt $loginAttempt/3)")
                 ctrl.sendTracked(buildLogin(ctrl))
-                r60 = ctrl.expect(96, byteArrayOf(0x60, 0, 0, 0, 0, 0, 0x01, 0), timeoutMs = 5000)
+                r60 = ctrl.expect(96, loginReply, timeoutMs = 5000)
             }
             if (r60 == null) {
                 fail("No login reply — is 'Network control' ON and the control port correct?")
@@ -273,10 +295,20 @@ class IcomNetworkManager : NetworkAudioRig {
                     it.sendTracked(buildSerialOpenClose(close = true))
                 }
             }
-            control?.let { c ->
-                repeat(3) { c.sendRaw(buildAuth(c, magic = 0x01)) }  // token remove
+            // Only deauth when a login actually delivered a token: zero-token
+            // removals after a connect that failed before login are junk the
+            // radio never asked for, and some models answer every 0x40 packet.
+            val haveToken = authID.any { it != 0.toByte() }
+            if (haveToken) {
+                control?.let { c ->
+                    repeat(3) { c.sendRaw(buildAuth(c, magic = 0x01)) }  // token remove
+                }
+                // The radio-side token is being removed right now; drop the
+                // persisted copy so the NEXT connect starts clean instead of
+                // opening with removal packets for a token that is long gone.
+                saveStaleToken?.invoke(null)
             }
-            Thread.sleep(120)
+            if (serialOpened || haveToken) Thread.sleep(120)
         } catch (_: Exception) {}
         try { audio?.close() } catch (_: Exception) {}
         try { serial?.close() } catch (_: Exception) {}
@@ -349,6 +381,9 @@ class IcomNetworkManager : NetworkAudioRig {
         ctrl.remoteSID = u32be(r, 8)
         ctrl.localSID = u32be(r, 12)
         System.arraycopy(r, 26, authID, 0, 6)
+        // The grant may refresh the token — keep the persisted copy current so
+        // an unclean exit removes the token the radio actually holds.
+        saveStaleToken?.invoke(authID.joinToString("") { "%02x".format(it) })
         val devName = parseCString(r, 64)
         _state.value = _state.value.copy(deviceName = devName)
         Log.i(TAG, "serial/audio granted, device='$devName' — opening CI-V stream")
@@ -621,15 +656,17 @@ class IcomNetworkManager : NetworkAudioRig {
     /** Token-removal (deauth) packet for an EXPLICIT token — used by the
      *  pre-login cleanup to delete the previous session's token. Identical to
      *  buildAuth(magic = 0x01) except the token bytes come from the argument
-     *  instead of the live authID. */
+     *  instead of the live authID, and the auth inner seq is left at 0 and NOT
+     *  advanced: the login that follows must still go out as authInnerSeq 0,
+     *  exactly as it does when there is no stale token — advancing it here made
+     *  the login leave as seq 3 and radios stricter than the IC-705 (the
+     *  IC-7300MK2) refused it. */
     private fun buildTokenRemove(s: IcomStream, token: ByteArray): ByteArray {
         val p = ByteArray(64)
         p[0] = 0x40
         p.putSid(8, s.localSID); p.putSid(12, s.remoteSID)
         p[19] = 0x30; p[20] = 0x01; p[21] = 0x01
-        p[23] = authInnerSeq.toByte(); p[24] = (authInnerSeq ushr 8).toByte()
         System.arraycopy(token, 0, p, 26, minOf(token.size, 6))
-        authInnerSeq = (authInnerSeq + 1) and 0xFFFF
         return p
     }
 
@@ -819,6 +856,11 @@ class IcomNetworkManager : NetworkAudioRig {
                     }
                 } catch (_: CancellationException) {}
             }
+        }
+
+        /** Discard every packet already queued on [incoming] (nothing blocks). */
+        fun drainPending() {
+            while (incoming.tryReceive().getOrNull() != null) { /* drop */ }
         }
 
         suspend fun expect(len: Int, prefix: ByteArray, timeoutMs: Long = 3000): ByteArray? =

--- a/docs/release-notes/v1.6.11.md
+++ b/docs/release-notes/v1.6.11.md
@@ -1,0 +1,37 @@
+# v1.6.11 — Icom Wi-Fi：IC-7300MK2 で v1.6.9 が接続できない問題を修正 / Fix v1.6.9 failing to connect to the IC-7300MK2
+
+ユーザー報告：**IC-7300MK2 に対して v1.6.9 の Icom Wi-Fi モードが接続できない**（v1.6.4 に戻すと接続できる）。調査の結果、v1.6.7〜v1.6.9 で入れた「再接続修正」に IC-705 以外の機種で致命的になる 3 つの欠陥が重なっていました。インストールは `app-debug.apk` をご利用ください。
+
+## 原因（日本語）
+
+1. **トークン削除パケットを毎回・無条件に送っていた** — v1.6.9 は保存したトークンの削除指令をすべての接続の最初に送りますが、保存値を**一度も消さない**ため、初回成功のあとは「もう存在しないトークンの削除指令」を毎回ログイン前に 3 発送っていました。
+2. **削除パケットが認証シーケンス番号を進めていた** — このためログインが本来の seq 0 ではなく seq 3 で送信され、IC-705 (fw1.41) は許容しても、より新しい IC-7300MK2 のサーバは受け付けません。
+3. **ログイン応答の判定が「無線機側の送信シーケンス番号 = 1」に固定されていた** — これはログイン応答が無線機の最初のトラッキング付きパケットである場合しか成立しません。IC-7300MK2 のように**ログイン前の削除指令に応答を返す機種**では番号がずれ、本物のログイン応答が届いているのにアプリが全部捨てて「No login reply」→ 永久に接続不能（保存トークンも消えないので毎回再発）になっていました。v1.6.4 にはこの 3 つが存在しないため、戻すと接続できたわけです。
+
+## 修正内容
+
+- ログイン前のトークン削除は**「前回が異常終了（接続中の強制終了など）だった場合だけ」の一回きり**になりました。送信した時点・正常切断した時点で保存値を消去します。
+- 削除パケットは認証シーケンス番号を進めません（ログインは常に seq 0 で送信、v1.6.4 と同一）。
+- ログイン応答の判定を長さ・タイプのみに変更（無線機側シーケンス番号に依存しない）。これで**ログイン再送 (3 回) が実際に機能する**ようになり、応答パケットが失われる LTE/VPN 経路でも再送で復帰します。
+- ログイン送信直前に受信キューを掃除（削除指令への無線機の応答をログイン応答と誤認しない）。
+- ログイン前に失敗した接続の後始末で、トークン無しのままの削除指令（ゴミパケット）を送らないようにしました。
+
+## LTE + VPN について
+
+v1.6.4 でも v1.6.9 でも LTE+VPN で接続できないという報告は、エラーが「Control handshake failed」の場合、**無線機が VPN サブネットへ応答を返せない**構成が最も典型的な原因です：無線機側にデフォルトゲートウェイが設定されていること（DHCP なら通常自動）、かつ VPN がクライアントに無線機と同じサブネットのアドレスを配る（FRITZ!Box 型）か、LAN へ NAT（マスカレード）することが必要です。エラーメッセージにこの説明を追加しました。ログイン段階まで到達するのに失敗する場合は、上記のログイン再送修正が効きます。
+
+## In English
+
+**Report (Manfred, DJ4MO):** v1.6.9's Icom Wi-Fi mode cannot connect to an IC-7300MK2 at all; downgrading to v1.6.4 connects fine. Three defects introduced across v1.6.7–v1.6.9 stacked up and only the IC-705 happened to tolerate them:
+
+1. **The stale-token removal ran on every connect and the persisted token was never cleared** — so after the first successful session, every connect opened by firing removal packets for a token the radio had long deleted.
+2. **Those removal packets advanced the auth inner sequence**, so the login left as seq 3 instead of seq 0. The IC-705 (fw 1.41) tolerates that; the IC-7300MK2's newer server does not.
+3. **The login-reply matcher was pinned to the radio's tracked sequence number 0x0001**, which only holds when the login reply is the radio's very first tracked packet. A radio that *answers* the pre-login removal (the IC-7300MK2 does, the IC-705 silently ignores it) shifts that sequence — the app then discarded every genuine login reply, showed "No login reply", and stayed wedged forever because the stale token was also never cleared. v1.6.4 predates all three, which is why it worked.
+
+**Fixed:** the pre-login token removal now runs only once, and only after an *unclean* exit (app killed while connected) — it is cleared the moment it is sent and on every clean disconnect; removal packets no longer touch the auth sequence (login always leaves as seq 0, identical to v1.6.4); the login reply is matched by length/type instead of the radio's running sequence number, which also makes the 3× login retry actually effective when a reply is lost in transit (LTE/VPN); the receive queue is drained just before the login is sent; and no token-less deauth junk is sent after connects that failed before login.
+
+**LTE + VPN:** the "cannot connect over LTE+VPN" seen on both v1.6.4 and v1.6.9 is, when the error is *Control handshake failed*, almost always the radio being unable to route replies back to the VPN subnet: the radio needs a default gateway (DHCP normally provides one), and the VPN must either give clients an address inside the radio's subnet (FRITZ!Box-style) or NAT/masquerade them into it (typical WireGuard/OpenVPN setups). The error message now explains this. Failures that reach the login stage are covered by the retry fix above.
+
+---
+
+**Full Changelog**: https://github.com/pepefrog1234/RADE_decode_Android/compare/v1.6.10...v1.6.11

--- a/docs/release-notes/v1.6.11.md
+++ b/docs/release-notes/v1.6.11.md
@@ -34,4 +34,6 @@ v1.6.4 でも v1.6.9 でも LTE+VPN で接続できないという報告は、�
 
 ---
 
-**Full Changelog**: https://github.com/pepefrog1234/RADE_decode_Android/compare/v1.6.10...v1.6.11
+このリリースには未公開だった v1.6.10 の修正（FreeDV Reporter に局が表示されない問題・手動周波数入力）も含まれます。詳細は `docs/release-notes/v1.6.10.md` を参照してください。 / This release also ships the previously unpublished v1.6.10 fixes (station never appearing on FreeDV Reporter + manual frequency entry) — see `docs/release-notes/v1.6.10.md`.
+
+**Full Changelog**: https://github.com/pepefrog1234/RADE_decode_Android/compare/v1.6.9...v1.6.11


### PR DESCRIPTION
## Summary

Field report (Manfred, DJ4MO): **v1.6.9's Icom Wi-Fi mode cannot connect to an IC-7300MK2 at all**, while downgrading to v1.6.4 connects fine. Three defects introduced across the v1.6.7–v1.6.9 reconnect fixes stacked up, and only the IC-705 happened to tolerate them:

1. **The persisted stale-token removal ran on every connect and the persisted token was never cleared** — after the first successful session, every connect opened by firing removal packets for a token the radio had already deleted on the clean disconnect.
2. **`buildTokenRemove` advanced `authInnerSeq`**, so with a persisted token the login left as inner seq 3 instead of 0. The IC-705 (fw 1.41) tolerates that; the IC-7300MK2's newer server does not.
3. **The login-reply matcher was pinned to the radio's tracked sequence number `0x0001`**, which only holds when the reply is the radio's very first tracked packet. A radio that *answers* the pre-login removal (the IC-7300MK2; the IC-705 silently ignores it) shifts that seq, so every genuine login reply was discarded → "No login reply", permanently — and the login retry loop could never recover, since a retry's reply carries seq ≥ 2 by definition.

## Changes (`IcomNetworkManager.kt`)

- Pre-login token removal is now **one-shot and only fires after an unclean exit** (app killed while connected): the persisted token is cleared the moment the removal is sent, and on every clean disconnect. Upgrading from v1.6.9 self-heals on the first connect — no radio power-cycle needed.
- `buildTokenRemove` no longer touches `authInnerSeq`; the login always goes out as inner seq 0, identical to the v1.6.4-verified behavior. The three removal repeats reuse identical bytes (the protocol's native retransmit idiom).
- The login reply is matched by **length/type (96-byte `0x60`)** instead of the radio's running sequence number — this also makes the 3× login retry actually effective when a reply is lost in transit (cold LTE/VPN paths).
- The control stream's receive queue is drained right before the login is sent, so a radio's ack to the removal can never be mistaken for the login reply.
- `disconnect()` only sends the deauth when a login actually delivered a token (no zero-token junk after failed connects) and only sleeps when something was sent.
- The persisted token follows the refreshed token from the serial grant.
- The control-handshake failure message now explains the usual LTE+VPN cause (radio needs a default gateway / the VPN must NAT clients into the radio's subnet) — that stage failing is radio-side reachability, not login.

Also: version bump to 1.6.11 (`versionCode 10611`) and bilingual release notes in `docs/release-notes/v1.6.11.md`.

## Validation

- `IcomNetworkManager.kt` compiles cleanly with the project's Kotlin 2.2.10 (standalone kotlinc check; no Android SDK in the dev environment).
- CI on this branch is green: unit tests + debug/release APK build ([run 33451500693](https://github.com/pepefrog1234/RADE_decode_Android/actions/runs/33451500693)).
- **Already released as [v1.6.11](https://github.com/pepefrog1234/RADE_decode_Android/releases/tag/v1.6.11)** — the tag points at this branch's head (`6014a4b`), so merging brings `main` in line with the published release. Field confirmation from the reporter is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GsCJNdC19g1bxtLXoo2RL

---
_Generated by [Claude Code](https://claude.ai/code/session_012GsCJNdC19g1bxtLXoo2RL)_